### PR TITLE
refactor: split geoip structre to avoid IP duplication in some derived works

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![dependency status](https://deps.rs/repo/github/runziggurat/ziggurat-core/status.svg)](https://deps.rs/repo/github/runziggurat/ziggurat-core)
+
 # ziggurat-core package
 
 *Note:* This project is a work in progress.

--- a/ziggurat-core-geoip/Cargo.toml
+++ b/ziggurat-core-geoip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ziggurat-core-geoip"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 homepage = "https://github.com/runziggurat/ziggurat-core"
@@ -17,5 +17,5 @@ rand = "0.8.5"
 serde = { version = "1", features = ["derive"] }
 
 [dependencies.tokio]
-version = "1"
+version = "1.24"
 features = ["full"]

--- a/ziggurat-core-geoip/src/geoip.rs
+++ b/ziggurat-core-geoip/src/geoip.rs
@@ -10,11 +10,18 @@ pub trait GeoIPService {
     async fn lookup(&self, ip: IpAddr) -> Result<GeoIPInfo, String>;
 }
 
-/// IP information
+/// GeoIP information.
 #[derive(Clone, Deserialize, Serialize)]
 pub struct GeoIPInfo {
     /// IP address
     pub ip: IpAddr,
+    /// GeoInfo struct
+    pub geo_info: GeoInfo,
+}
+
+/// Geo information
+#[derive(Clone, Deserialize, Serialize)]
+pub struct GeoInfo {
     /// Country name (long name)
     pub country: Option<String>,
     /// City name

--- a/ziggurat-core-geoip/src/providers/ip2loc.rs
+++ b/ziggurat-core-geoip/src/providers/ip2loc.rs
@@ -3,7 +3,7 @@ use std::net::IpAddr;
 use async_trait::async_trait;
 use ip2location::{Record, DB};
 
-use crate::geoip::{GeoIPInfo, GeoIPService};
+use crate::geoip::{GeoIPInfo, GeoIPService, GeoInfo};
 
 /// Ip2Location provider service configuration.
 #[derive(Copy, Clone)]
@@ -33,12 +33,14 @@ impl GeoIPService for Ip2LocationService {
 
         Ok(GeoIPInfo {
             ip,
-            country: record.country.map(|c| c.long_name),
-            city: record.city,
-            latitude: record.latitude.map(|lat| lat as f64),
-            longitude: record.longitude.map(|long| long as f64),
-            timezone: record.time_zone,
-            isp: record.isp,
+            geo_info: GeoInfo {
+                country: record.country.map(|c| c.long_name),
+                city: record.city,
+                latitude: record.latitude.map(|lat| lat as f64),
+                longitude: record.longitude.map(|long| long as f64),
+                timezone: record.time_zone,
+                isp: record.isp,
+            },
         })
     }
 }

--- a/ziggurat-core-geoip/src/providers/ipgeoloc.rs
+++ b/ziggurat-core-geoip/src/providers/ipgeoloc.rs
@@ -3,7 +3,7 @@ use std::net::IpAddr;
 use async_trait::async_trait;
 use ipgeolocate::{Locator, Service};
 
-use crate::geoip::{GeoIPInfo, GeoIPService};
+use crate::geoip::{GeoIPInfo, GeoIPService, GeoInfo};
 
 /// List of supported ipgeolocate providers.
 #[derive(Copy, Clone, PartialEq)]
@@ -39,12 +39,14 @@ impl GeoIPService for IpGeolocateService {
         match Locator::get(ip.to_string().as_str(), service).await {
             Ok(loc_ip) => Ok(GeoIPInfo {
                 ip,
-                country: Some(loc_ip.country),
-                city: Some(loc_ip.city),
-                latitude: loc_ip.latitude.parse::<f64>().ok(),
-                longitude: loc_ip.longitude.parse::<f64>().ok(),
-                timezone: Some(loc_ip.timezone),
-                isp: Some("".to_owned()),
+                geo_info: GeoInfo {
+                    country: Some(loc_ip.country),
+                    city: Some(loc_ip.city),
+                    latitude: loc_ip.latitude.parse::<f64>().ok(),
+                    longitude: loc_ip.longitude.parse::<f64>().ok(),
+                    timezone: Some(loc_ip.timezone),
+                    isp: Some("".to_owned()),
+                },
             }),
             Err(error) => Err(error.to_string()),
         }
@@ -59,21 +61,21 @@ mod tests {
     async fn test_ip_api_com() {
         let geoip = IpGeolocateService::new(BackendProvider::IpApiCom, "");
         let ipgeo = geoip.lookup("8.8.8.8".parse().unwrap()).await.unwrap();
-        assert_eq!(ipgeo.country.unwrap(), "United States");
-        assert_eq!(ipgeo.city.unwrap(), "Ashburn");
-        assert_eq!(ipgeo.latitude.unwrap(), 39.03);
-        assert_eq!(ipgeo.longitude.unwrap(), -77.5);
-        assert_eq!(ipgeo.timezone.unwrap(), "America/New_York");
+        assert_eq!(ipgeo.geo_info.country.unwrap(), "United States");
+        assert_eq!(ipgeo.geo_info.city.unwrap(), "Ashburn");
+        assert_eq!(ipgeo.geo_info.latitude.unwrap(), 39.03);
+        assert_eq!(ipgeo.geo_info.longitude.unwrap(), -77.5);
+        assert_eq!(ipgeo.geo_info.timezone.unwrap(), "America/New_York");
     }
 
     #[tokio::test]
     async fn test_ip_api_co() {
         let geoip = IpGeolocateService::new(BackendProvider::IpApiCo, "");
         let ipgeo = geoip.lookup("8.8.8.8".parse().unwrap()).await.unwrap();
-        assert_eq!(ipgeo.country.unwrap(), "United States");
-        assert_eq!(ipgeo.city.unwrap(), "Mountain View");
-        assert_eq!(ipgeo.latitude.unwrap(), 37.42301);
-        assert_eq!(ipgeo.longitude.unwrap(), -122.083352);
-        assert_eq!(ipgeo.timezone.unwrap(), "America/Los_Angeles");
+        assert_eq!(ipgeo.geo_info.country.unwrap(), "United States");
+        assert_eq!(ipgeo.geo_info.city.unwrap(), "Mountain View");
+        assert_eq!(ipgeo.geo_info.latitude.unwrap(), 37.42301);
+        assert_eq!(ipgeo.geo_info.longitude.unwrap(), -122.083352);
+        assert_eq!(ipgeo.geo_info.timezone.unwrap(), "America/Los_Angeles");
     }
 }

--- a/ziggurat-core-geoip/src/providers/testing.rs
+++ b/ziggurat-core-geoip/src/providers/testing.rs
@@ -3,7 +3,7 @@ use std::net::IpAddr;
 use async_trait::async_trait;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
-use crate::geoip::{GeoIPInfo, GeoIPService};
+use crate::geoip::{GeoIPInfo, GeoIPService, GeoInfo};
 
 /// List of supported testing providers.
 #[derive(Copy, Clone, PartialEq)]
@@ -33,46 +33,50 @@ impl GeoIPService for TestingService {
         if self.provider == TestingProvider::Zeroed {
             Ok(GeoIPInfo {
                 ip,
-                country: Some("".to_owned()),
-                city: Some("".to_owned()),
-                latitude: Some(0.0),
-                longitude: Some(0.0),
-                timezone: Some("".to_owned()),
-                isp: Some("".to_owned()),
+                geo_info: GeoInfo {
+                    country: Some("".to_owned()),
+                    city: Some("".to_owned()),
+                    latitude: Some(0.0),
+                    longitude: Some(0.0),
+                    timezone: Some("".to_owned()),
+                    isp: Some("".to_owned()),
+                },
             })
         } else {
             Ok(GeoIPInfo {
                 ip,
-                country: Some(
-                    thread_rng()
-                        .sample_iter(&Alphanumeric)
-                        .take(8)
-                        .map(char::from)
-                        .collect(),
-                ),
-                city: Some(
-                    thread_rng()
-                        .sample_iter(&Alphanumeric)
-                        .take(8)
-                        .map(char::from)
-                        .collect(),
-                ),
-                latitude: Some(thread_rng().gen_range(-90.0..90.0)),
-                longitude: Some(thread_rng().gen_range(-180.0..180.0)),
-                timezone: Some(
-                    thread_rng()
-                        .sample_iter(&Alphanumeric)
-                        .take(8)
-                        .map(char::from)
-                        .collect(),
-                ),
-                isp: Some(
-                    thread_rng()
-                        .sample_iter(&Alphanumeric)
-                        .take(8)
-                        .map(char::from)
-                        .collect(),
-                ),
+                geo_info: GeoInfo {
+                    country: Some(
+                        thread_rng()
+                            .sample_iter(&Alphanumeric)
+                            .take(8)
+                            .map(char::from)
+                            .collect(),
+                    ),
+                    city: Some(
+                        thread_rng()
+                            .sample_iter(&Alphanumeric)
+                            .take(8)
+                            .map(char::from)
+                            .collect(),
+                    ),
+                    latitude: Some(thread_rng().gen_range(-90.0..90.0)),
+                    longitude: Some(thread_rng().gen_range(-180.0..180.0)),
+                    timezone: Some(
+                        thread_rng()
+                            .sample_iter(&Alphanumeric)
+                            .take(8)
+                            .map(char::from)
+                            .collect(),
+                    ),
+                    isp: Some(
+                        thread_rng()
+                            .sample_iter(&Alphanumeric)
+                            .take(8)
+                            .map(char::from)
+                            .collect(),
+                    ),
+                },
             })
         }
     }
@@ -86,10 +90,10 @@ mod tests {
     async fn test_testing_provider() {
         let geoip = TestingService::new(TestingProvider::Zeroed);
         let ipgeo = geoip.lookup("8.8.8.8".parse().unwrap()).await.unwrap();
-        assert_eq!(ipgeo.country.unwrap(), "");
-        assert_eq!(ipgeo.city.unwrap(), "");
-        assert_eq!(ipgeo.latitude.unwrap(), 0.0);
-        assert_eq!(ipgeo.longitude.unwrap(), 0.0);
-        assert_eq!(ipgeo.timezone.unwrap(), "");
+        assert_eq!(ipgeo.geo_info.country.unwrap(), "");
+        assert_eq!(ipgeo.geo_info.city.unwrap(), "");
+        assert_eq!(ipgeo.geo_info.latitude.unwrap(), 0.0);
+        assert_eq!(ipgeo.geo_info.longitude.unwrap(), 0.0);
+        assert_eq!(ipgeo.geo_info.timezone.unwrap(), "");
     }
 }


### PR DESCRIPTION
Now it's possible to choose if serialized is whole GeoIPInfo structure (IP + geolocation) or only `GeoInfo` structure describing only location part. 
More info and change context:
https://github.com/runziggurat/crunchy/pull/2#discussion_r1085138535
