### PR TITLE
refactor: use String as struct member for db location and api keys

### DIFF
--- a/ziggurat-core-geoip/Cargo.toml
+++ b/ziggurat-core-geoip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ziggurat-core-geoip"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 homepage = "https://github.com/runziggurat/ziggurat-core"

--- a/ziggurat-core-geoip/src/providers/ip2loc.rs
+++ b/ziggurat-core-geoip/src/providers/ip2loc.rs
@@ -6,15 +6,17 @@ use ip2location::{Record, DB};
 use crate::geoip::{GeoIPInfo, GeoIPService, GeoInfo};
 
 /// Ip2Location provider service configuration.
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct Ip2LocationService {
     /// Database file path.
-    pub database_file: &'static str,
+    pub database_file: String,
 }
 
 impl Ip2LocationService {
-    pub fn new(database_file: &'static str) -> Self {
-        Self { database_file }
+    pub fn new(database_file: &str) -> Self {
+        Self {
+            database_file: database_file.to_owned(),
+        }
     }
 }
 
@@ -22,7 +24,7 @@ impl Ip2LocationService {
 impl GeoIPService for Ip2LocationService {
     async fn lookup(&self, ip: IpAddr) -> Result<GeoIPInfo, String> {
         let mut db =
-            DB::from_file(self.database_file).map_err(|_| "database file can't be loaded")?;
+            DB::from_file(&self.database_file).map_err(|_| "database file can't be loaded")?;
 
         let record = db.ip_lookup(ip);
         let record = if let Ok(Record::LocationDb(rec)) = record {

--- a/ziggurat-core-geoip/src/providers/ipgeoloc.rs
+++ b/ziggurat-core-geoip/src/providers/ipgeoloc.rs
@@ -13,17 +13,20 @@ pub enum BackendProvider {
 }
 
 /// ipgeolocate provider service configuration.
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct IpGeolocateService {
     /// Geoip provider.
     pub provider: BackendProvider,
     /// API key.
-    pub api_key: &'static str,
+    pub api_key: String,
 }
 
 impl IpGeolocateService {
-    pub fn new(provider: BackendProvider, api_key: &'static str) -> Self {
-        Self { provider, api_key }
+    pub fn new(provider: BackendProvider, api_key: &str) -> Self {
+        Self {
+            provider,
+            api_key: api_key.to_owned(),
+        }
     }
 }
 


### PR DESCRIPTION
Change to make using library with loaded (eg. from file) values easier.