### PR TITLE
refactor: create and use Location struct with latitude and longitude values

### DIFF
--- a/ziggurat-core-geoip/Cargo.toml
+++ b/ziggurat-core-geoip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ziggurat-core-geoip"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 homepage = "https://github.com/runziggurat/ziggurat-core"

--- a/ziggurat-core-geoip/src/geoip.rs
+++ b/ziggurat-core-geoip/src/geoip.rs
@@ -43,10 +43,12 @@ pub struct GeoInfo {
     pub isp: Option<String>,
 }
 
-
 impl Location {
     /// Create a new Location struct.
     pub fn new(latitude: f64, longitude: f64) -> Self {
-        Self { latitude, longitude }
+        Self {
+            latitude,
+            longitude,
+        }
     }
 }

--- a/ziggurat-core-geoip/src/geoip.rs
+++ b/ziggurat-core-geoip/src/geoip.rs
@@ -19,6 +19,15 @@ pub struct GeoIPInfo {
     pub geo_info: GeoInfo,
 }
 
+/// Geographical location
+#[derive(Copy, Clone, Deserialize, Serialize)]
+pub struct Location {
+    /// Latitude value
+    pub latitude: f64,
+    /// Longitude value
+    pub longitude: f64,
+}
+
 /// Geo information
 #[derive(Clone, Deserialize, Serialize)]
 pub struct GeoInfo {
@@ -26,12 +35,18 @@ pub struct GeoInfo {
     pub country: Option<String>,
     /// City name
     pub city: Option<String>,
-    /// Latitude
-    pub latitude: Option<f64>,
-    /// Longitude
-    pub longitude: Option<f64>,
+    /// Location of the IP address
+    pub location: Option<Location>,
     /// Timezone of the IP
     pub timezone: Option<String>,
     /// ISP name (unavailable for some providers)
     pub isp: Option<String>,
+}
+
+
+impl Location {
+    /// Create a new Location struct.
+    pub fn new(latitude: f64, longitude: f64) -> Self {
+        Self { latitude, longitude }
+    }
 }

--- a/ziggurat-core-geoip/src/providers/ip2loc.rs
+++ b/ziggurat-core-geoip/src/providers/ip2loc.rs
@@ -3,7 +3,7 @@ use std::net::IpAddr;
 use async_trait::async_trait;
 use ip2location::{Record, DB};
 
-use crate::geoip::{GeoIPInfo, GeoIPService, GeoInfo};
+use crate::geoip::{GeoIPInfo, GeoIPService, GeoInfo, Location};
 
 /// Ip2Location provider service configuration.
 #[derive(Clone)]
@@ -38,8 +38,13 @@ impl GeoIPService for Ip2LocationService {
             geo_info: GeoInfo {
                 country: record.country.map(|c| c.long_name),
                 city: record.city,
-                latitude: record.latitude.map(|lat| lat as f64),
-                longitude: record.longitude.map(|long| long as f64),
+                location: match (record.latitude, record.longitude) {
+                    (Some(lat), Some(long)) => Some(Location {
+                        latitude: lat as f64,
+                        longitude: long as f64,
+                    }),
+                    _ => None,
+                },
                 timezone: record.time_zone,
                 isp: record.isp,
             },

--- a/ziggurat-core-geoip/src/providers/ipgeoloc.rs
+++ b/ziggurat-core-geoip/src/providers/ipgeoloc.rs
@@ -3,7 +3,7 @@ use std::net::IpAddr;
 use async_trait::async_trait;
 use ipgeolocate::{Locator, Service};
 
-use crate::geoip::{GeoIPInfo, GeoIPService, GeoInfo};
+use crate::geoip::{GeoIPInfo, GeoIPService, GeoInfo, Location};
 
 /// List of supported ipgeolocate providers.
 #[derive(Copy, Clone, PartialEq)]
@@ -45,8 +45,10 @@ impl GeoIPService for IpGeolocateService {
                 geo_info: GeoInfo {
                     country: Some(loc_ip.country),
                     city: Some(loc_ip.city),
-                    latitude: loc_ip.latitude.parse::<f64>().ok(),
-                    longitude: loc_ip.longitude.parse::<f64>().ok(),
+                    location: Some(Location {
+                        latitude: loc_ip.latitude.parse::<f64>().unwrap_or_default(),
+                        longitude: loc_ip.longitude.parse::<f64>().unwrap_or_default(),
+                    }),
                     timezone: Some(loc_ip.timezone),
                     isp: Some("".to_owned()),
                 },
@@ -66,8 +68,8 @@ mod tests {
         let ipgeo = geoip.lookup("8.8.8.8".parse().unwrap()).await.unwrap();
         assert_eq!(ipgeo.geo_info.country.unwrap(), "United States");
         assert_eq!(ipgeo.geo_info.city.unwrap(), "Ashburn");
-        assert_eq!(ipgeo.geo_info.latitude.unwrap(), 39.03);
-        assert_eq!(ipgeo.geo_info.longitude.unwrap(), -77.5);
+        assert_eq!(ipgeo.geo_info.location.unwrap().latitude, 39.03);
+        assert_eq!(ipgeo.geo_info.location.unwrap().longitude, -77.5);
         assert_eq!(ipgeo.geo_info.timezone.unwrap(), "America/New_York");
     }
 
@@ -77,8 +79,8 @@ mod tests {
         let ipgeo = geoip.lookup("8.8.8.8".parse().unwrap()).await.unwrap();
         assert_eq!(ipgeo.geo_info.country.unwrap(), "United States");
         assert_eq!(ipgeo.geo_info.city.unwrap(), "Mountain View");
-        assert_eq!(ipgeo.geo_info.latitude.unwrap(), 37.42301);
-        assert_eq!(ipgeo.geo_info.longitude.unwrap(), -122.083352);
+        assert_eq!(ipgeo.geo_info.location.unwrap().latitude, 37.42301);
+        assert_eq!(ipgeo.geo_info.location.unwrap().longitude, -122.083352);
         assert_eq!(ipgeo.geo_info.timezone.unwrap(), "America/Los_Angeles");
     }
 }

--- a/ziggurat-core-geoip/src/providers/testing.rs
+++ b/ziggurat-core-geoip/src/providers/testing.rs
@@ -3,7 +3,7 @@ use std::net::IpAddr;
 use async_trait::async_trait;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
-use crate::geoip::{GeoIPInfo, GeoIPService, GeoInfo};
+use crate::geoip::{GeoIPInfo, GeoIPService, GeoInfo, Location};
 
 /// List of supported testing providers.
 #[derive(Copy, Clone, PartialEq)]
@@ -36,8 +36,10 @@ impl GeoIPService for TestingService {
                 geo_info: GeoInfo {
                     country: Some("".to_owned()),
                     city: Some("".to_owned()),
-                    latitude: Some(0.0),
-                    longitude: Some(0.0),
+                    location: Some(Location {
+                        latitude: 0.0,
+                        longitude: 0.0,
+                    }),
                     timezone: Some("".to_owned()),
                     isp: Some("".to_owned()),
                 },
@@ -60,8 +62,10 @@ impl GeoIPService for TestingService {
                             .map(char::from)
                             .collect(),
                     ),
-                    latitude: Some(thread_rng().gen_range(-90.0..90.0)),
-                    longitude: Some(thread_rng().gen_range(-180.0..180.0)),
+                    location: Some(Location {
+                        latitude: thread_rng().gen_range(-90.0..=90.0),
+                        longitude: thread_rng().gen_range(-180.0..=180.0),
+                    }),
                     timezone: Some(
                         thread_rng()
                             .sample_iter(&Alphanumeric)
@@ -92,8 +96,8 @@ mod tests {
         let ipgeo = geoip.lookup("8.8.8.8".parse().unwrap()).await.unwrap();
         assert_eq!(ipgeo.geo_info.country.unwrap(), "");
         assert_eq!(ipgeo.geo_info.city.unwrap(), "");
-        assert_eq!(ipgeo.geo_info.latitude.unwrap(), 0.0);
-        assert_eq!(ipgeo.geo_info.longitude.unwrap(), 0.0);
+        assert_eq!(ipgeo.geo_info.location.unwrap().latitude, 0.0);
+        assert_eq!(ipgeo.geo_info.location.unwrap().longitude, 0.0);
         assert_eq!(ipgeo.geo_info.timezone.unwrap(), "");
     }
 }


### PR DESCRIPTION
Introduced `Location` structure with longitude and latitude fields. Updated providers respectively.