### PR TITLE
refactor: remove AGraph & spectre dependency

### DIFF
--- a/ziggurat-core-crawler/Cargo.toml
+++ b/ziggurat-core-crawler/Cargo.toml
@@ -10,4 +10,4 @@ description = "A crawler package for ziggurat-based projects"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-spectre = "0.5.1"
+

--- a/ziggurat-core-crawler/src/summary.rs
+++ b/ziggurat-core-crawler/src/summary.rs
@@ -1,7 +1,6 @@
 use std::{cmp, collections::HashMap, fmt, fs, path::Path, time::Duration};
 
 use serde::{Deserialize, Serialize};
-use spectre::graph::AGraph;
 
 /// Contains stats about crawled network.
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -23,7 +22,7 @@ pub struct NetworkSummary {
     /// Addresses of good nodes.
     pub node_ips: Vec<String>,
     /// Unidirected connections graph.
-    pub agraph: AGraph,
+    pub indices: Vec<Vec<usize>>,
 }
 
 impl NetworkSummary {


### PR DESCRIPTION
Use `Vec<Vec<usize>>` instead of `AGraph` from spectre.  AGraph is gone from that library, so dependency may also be removed.