### PR TITLE
Replace IpAddr wth SocketAddr, add NodeIndices type

### DIFF
--- a/ziggurat-core-crawler/src/connection.rs
+++ b/ziggurat-core-crawler/src/connection.rs
@@ -1,7 +1,7 @@
 use std::{
     cmp::Ordering,
     hash::{Hash, Hasher},
-    net::IpAddr,
+    net::SocketAddr,
     time::Instant,
 };
 
@@ -9,9 +9,9 @@ use std::{
 #[derive(Debug, Eq, Copy, Clone)]
 pub struct KnownConnection {
     /// One of the two sides of a connection.
-    pub a: IpAddr,
+    pub a: SocketAddr,
     /// The other side of a connection.
-    pub b: IpAddr,
+    pub b: SocketAddr,
     /// The timestamp of the last time the connection was seen.
     pub last_seen: Instant,
 }
@@ -35,7 +35,7 @@ impl Hash for KnownConnection {
 }
 
 impl KnownConnection {
-    pub fn new(a: IpAddr, b: IpAddr) -> Self {
+    pub fn new(a: SocketAddr, b: SocketAddr) -> Self {
         Self {
             a,
             b,
@@ -55,14 +55,14 @@ impl PartialEq for KnownConnection {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashSet, net::IpAddr, str::FromStr};
+    use std::{collections::HashSet, net::SocketAddr, str::FromStr};
 
     use crate::connection::KnownConnection;
 
     #[test]
     fn should_deal_with_reverse_connection() {
-        let a = IpAddr::from_str("1.2.3.4").unwrap();
-        let b = IpAddr::from_str("1.2.3.5").unwrap();
+        let a = SocketAddr::from_str("1.2.3.4:3000").unwrap();
+        let b = SocketAddr::from_str("1.2.3.5:3000").unwrap();
         let connection_present = KnownConnection::new(a, b);
         let connection_reverse = KnownConnection::new(b, a);
         assert_eq!(connection_present, connection_reverse);

--- a/ziggurat-core-crawler/src/summary.rs
+++ b/ziggurat-core-crawler/src/summary.rs
@@ -2,6 +2,8 @@ use std::{cmp, collections::HashMap, fmt, fs, net::SocketAddr, path::Path, time:
 
 use serde::{Deserialize, Serialize};
 
+// This struct contains a list of connection indices for each node
+// It is equivalent to an adjacency or degree matrix, expressed in a compact form
 type NodeIndices = Vec<Vec<usize>>;
 
 /// Contains stats about crawled network.

--- a/ziggurat-core-crawler/src/summary.rs
+++ b/ziggurat-core-crawler/src/summary.rs
@@ -24,7 +24,7 @@ pub struct NetworkSummary {
     /// Addresses of good nodes.
     pub node_addrs: Vec<SocketAddr>,
     /// Unidirected connections graph.
-    pub indices: NodeIndices,
+    pub node_indices: NodeIndices,
 }
 
 impl NetworkSummary {

--- a/ziggurat-core-crawler/src/summary.rs
+++ b/ziggurat-core-crawler/src/summary.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 // This struct contains a list of connection indices for each node
 // It is equivalent to an adjacency or degree matrix, expressed in a compact form
-type NodeIndices = Vec<Vec<usize>>;
+type GraphIndices = Vec<Vec<usize>>;
 
 /// Contains stats about crawled network.
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -26,7 +26,7 @@ pub struct NetworkSummary {
     /// Addresses of good nodes.
     pub node_addrs: Vec<SocketAddr>,
     /// Unidirected connections graph.
-    pub node_indices: NodeIndices,
+    pub graph_indices: GraphIndices,
 }
 
 impl NetworkSummary {

--- a/ziggurat-core-crawler/src/summary.rs
+++ b/ziggurat-core-crawler/src/summary.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 // This struct contains a list of connection indices for each node
 // It is equivalent to an adjacency or degree matrix, expressed in a compact form
-type GraphIndices = Vec<Vec<usize>>;
+type NodesIndices = Vec<Vec<usize>>;
 
 /// Contains stats about crawled network.
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -26,7 +26,7 @@ pub struct NetworkSummary {
     /// Addresses of good nodes.
     pub node_addrs: Vec<SocketAddr>,
     /// Unidirected connections graph.
-    pub graph_indices: GraphIndices,
+    pub nodes_indices: NodesIndices,
 }
 
 impl NetworkSummary {

--- a/ziggurat-core-crawler/src/summary.rs
+++ b/ziggurat-core-crawler/src/summary.rs
@@ -1,6 +1,8 @@
-use std::{cmp, collections::HashMap, fmt, fs, path::Path, time::Duration};
+use std::{cmp, collections::HashMap, fmt, fs, net::SocketAddr, path::Path, time::Duration};
 
 use serde::{Deserialize, Serialize};
+
+type NodeIndices = Vec<Vec<usize>>;
 
 /// Contains stats about crawled network.
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -20,9 +22,9 @@ pub struct NetworkSummary {
     /// Crawler's runtime.
     pub crawler_runtime: Duration,
     /// Addresses of good nodes.
-    pub node_ips: Vec<String>,
+    pub node_addrs: Vec<SocketAddr>,
     /// Unidirected connections graph.
-    pub indices: Vec<Vec<usize>>,
+    pub indices: NodeIndices,
 }
 
 impl NetworkSummary {


### PR DESCRIPTION
- We now have a type defined for `Vec<Vec<usize>>`, earlier known as `AGraph`.  We are explicitly defining this outside of the `spectre` library
- We've added the port number back with the ip address for node key (`SocketAddr` instead of `Ipaddr`)