### PR TITLE
feat: added NetworkType enum and included passing type of network for each node in NetworkSummary

### DIFF
--- a/ziggurat-core-crawler/Cargo.toml
+++ b/ziggurat-core-crawler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ziggurat-core-crawler"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 homepage = "https://github.com/runziggurat/ziggurat-core"

--- a/ziggurat-core-crawler/src/summary.rs
+++ b/ziggurat-core-crawler/src/summary.rs
@@ -6,6 +6,15 @@ use serde::{Deserialize, Serialize};
 // It is equivalent to an adjacency or degree matrix, expressed in a compact form
 pub type NodesIndices = Vec<Vec<usize>>;
 
+/// Enumaration of known networks that node can belong to.
+#[derive(Default, Clone, Deserialize, Serialize)]
+pub enum NetworkType {
+    #[default]
+    Unknown,
+    Zcash,
+    Ripple,
+}
+
 /// Contains stats about crawled network.
 #[derive(Default, Clone, Deserialize, Serialize)]
 pub struct NetworkSummary {
@@ -25,6 +34,8 @@ pub struct NetworkSummary {
     pub crawler_runtime: Duration,
     /// Addresses of good nodes.
     pub node_addrs: Vec<SocketAddr>,
+    /// Network types of good nodes. Indexes correspond to `node_addrs` and `node_indices`.
+    pub node_networks: Vec<NetworkType>,
     /// Unidirected connections graph.
     pub nodes_indices: NodesIndices,
 }

--- a/ziggurat-core-crawler/src/summary.rs
+++ b/ziggurat-core-crawler/src/summary.rs
@@ -35,7 +35,7 @@ pub struct NetworkSummary {
     /// Addresses of good nodes.
     pub node_addrs: Vec<SocketAddr>,
     /// Network types of good nodes. Indexes correspond to `node_addrs` and `node_indices`.
-    pub node_networks: Vec<NetworkType>,
+    pub node_network_types: Vec<NetworkType>,
     /// Unidirected connections graph.
     pub nodes_indices: NodesIndices,
 }


### PR DESCRIPTION
Each node should be identified also by the network as it occured, different nodes with similar protocol implementation can be taken as working inside one network. 
There is now a need to distinguish networks and that should be done by crawler (using eg. ports, versions, block sizes etc) and then passed to other apps (like crunchy) to visualize or alert the user about some unusual situation (like nodes from different networks connecting to each other). 
This PR is the first one changing common `NetworkSummary` type to include that information. 
I can see a place to potential refactorization and create struct with `Node` which could collect information about IP, network and indices but for now the aim is to introduce new feat without bigger changes in zcash or xrpl crawlers.