### PR TITLE
chore: make `check-and-lint` callable

### DIFF
--- a/.github/workflows/check-and-lint.yml
+++ b/.github/workflows/check-and-lint.yml
@@ -1,55 +1,33 @@
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  workflow_call:
 
 name: basics
 
 jobs:
   check:
-    name: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-targets
+      - uses: actions/checkout@v3
+      - run: cargo check --all-targets
 
   fmt:
-    name: fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - uses: actions/checkout@v3
+      - run: rustup toolchain install nightly --profile minimal
+      - run: rustup component add rustfmt --toolchain nightly
+      - run: cargo +nightly fmt --all -- --check
 
   clippy:
-    name: clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: clippy
-          override: true
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets -- -D warnings
-          name: clippy output
+      - uses: actions/checkout@v3
+      - run: cargo clippy --all-targets -- -D warnings
+
+  sort:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: cargo install cargo-sort
+      - run: cargo sort
+      - run: git diff --exit-code


### PR DESCRIPTION
- Makes the workflow callable from other sources.
- Introduces a new step, `sort`, that makes sure that `Cargo.toml` is sorted in alphabetical order. 