### PR TITLE
chore: remove git step

### DIFF
--- a/.github/workflows/process-results.yml
+++ b/.github/workflows/process-results.yml
@@ -30,11 +30,3 @@ jobs:
           cd results/$NAME
           cp latest.$EXTENSION $FILENAME.$EXTENSION
           gzip $FILENAME.$EXTENSION
-      - name: Git
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git pull
-          git add results/$NAME
-          git commit -m "ci: $NAME suite results"
-          git push


### PR DESCRIPTION
Removes the git step in the `process-results` workflow, so we don't accidentally push up new results.