### PR TITLE
Extend NetworkType with From<&str>, Copy, Debug traits

### DIFF
--- a/ziggurat-core-crawler/src/summary.rs
+++ b/ziggurat-core-crawler/src/summary.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub type NodesIndices = Vec<Vec<usize>>;
 
 /// Enumaration of known networks that node can belong to.
-#[derive(Default, PartialEq, Clone, Deserialize, Serialize, Debug)]
+#[derive(Default, PartialEq, Clone, Deserialize, Serialize, Debug, Copy)]
 pub enum NetworkType {
     #[default]
     Unknown,

--- a/ziggurat-core-crawler/src/summary.rs
+++ b/ziggurat-core-crawler/src/summary.rs
@@ -1,5 +1,5 @@
 use std::{
-    cmp, collections::HashMap, fmt, fs, net::SocketAddr, path::Path, str::FromStr, time::Duration,
+    cmp, collections::HashMap, fmt, fs, net::SocketAddr, path::Path, time::Duration,
 };
 
 use serde::{Deserialize, Serialize};
@@ -15,6 +15,17 @@ pub enum NetworkType {
     Unknown,
     Zcash,
     Ripple,
+}
+
+impl From<&str> for NetworkType {
+    fn from(input: &str) -> NetworkType {
+        match input {
+            "Unknown" => NetworkType::Unknown,
+            "Zcash" => NetworkType::Zcash,
+            "Ripple" => NetworkType::Ripple,
+            _ => NetworkType::Unknown,
+        }
+    }
 }
 
 /// Contains stats about crawled network.
@@ -92,17 +103,5 @@ impl fmt::Display for NetworkSummary {
         )?;
 
         Ok(())
-    }
-}
-
-impl FromStr for NetworkType {
-    type Err = ();
-    fn from_str(input: &str) -> Result<NetworkType, Self::Err> {
-        match input {
-            "Unknown" => Ok(NetworkType::Unknown),
-            "Zcash" => Ok(NetworkType::Zcash),
-            "Ripple" => Ok(NetworkType::Ripple),
-            _ => Err(()),
-        }
     }
 }

--- a/ziggurat-core-crawler/src/summary.rs
+++ b/ziggurat-core-crawler/src/summary.rs
@@ -1,6 +1,4 @@
-use std::{
-    cmp, collections::HashMap, fmt, fs, net::SocketAddr, path::Path, time::Duration,
-};
+use std::{cmp, collections::HashMap, fmt, fs, net::SocketAddr, path::Path, time::Duration};
 
 use serde::{Deserialize, Serialize};
 
@@ -15,6 +13,7 @@ pub enum NetworkType {
     Unknown,
     Zcash,
     Ripple,
+    Invalid,
 }
 
 impl From<&str> for NetworkType {
@@ -23,7 +22,7 @@ impl From<&str> for NetworkType {
             "Unknown" => NetworkType::Unknown,
             "Zcash" => NetworkType::Zcash,
             "Ripple" => NetworkType::Ripple,
-            _ => NetworkType::Unknown,
+            _ => NetworkType::Invalid,
         }
     }
 }

--- a/ziggurat-core-crawler/src/summary.rs
+++ b/ziggurat-core-crawler/src/summary.rs
@@ -1,4 +1,6 @@
-use std::{cmp, collections::HashMap, fmt, fs, net::SocketAddr, path::Path, time::Duration};
+use std::{
+    cmp, collections::HashMap, fmt, fs, net::SocketAddr, path::Path, str::FromStr, time::Duration,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -90,5 +92,17 @@ impl fmt::Display for NetworkSummary {
         )?;
 
         Ok(())
+    }
+}
+
+impl FromStr for NetworkType {
+    type Err = ();
+    fn from_str(input: &str) -> Result<NetworkType, Self::Err> {
+        match input {
+            "Unknown" => Ok(NetworkType::Unknown),
+            "Zcash" => Ok(NetworkType::Zcash),
+            "Ripple" => Ok(NetworkType::Ripple),
+            _ => Err(()),
+        }
     }
 }

--- a/ziggurat-core-crawler/src/summary.rs
+++ b/ziggurat-core-crawler/src/summary.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub type NodesIndices = Vec<Vec<usize>>;
 
 /// Enumaration of known networks that node can belong to.
-#[derive(Default, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Default, PartialEq, Clone, Deserialize, Serialize, Debug)]
 pub enum NetworkType {
     #[default]
     Unknown,


### PR DESCRIPTION
- these changes were required for `crunchy` and working with the `clap` command line parsing
- added `Invalid` enum value