### PR TITLE
Add `filter` input for `build-viz-state` workflow.

### DIFF
--- a/.github/workflows/build-viz-state.yml
+++ b/.github/workflows/build-viz-state.yml
@@ -3,12 +3,9 @@ on:
     inputs:
       filter:
         type: string
-        default: "Unknown"
 jobs:
   viz-state:
     runs-on: ubuntu-latest
-    env:
-      FILTER: ${{ inputs.filter  }}
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -17,7 +14,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: runziggurat/crunchy
-      - run: cargo run --release -- -f $FILTER -i latest.json -o latest.viz.json
+      - if: ${{ inputs.filter != "" }}
+        name: Generate filtered state
+        run: cargo run --release -- -f {{ inputs.filter }} -i latest.json -o latest.viz.json
+      - if: ${{ inputs.filter == "" }}
+        name: Generate unfiltered state
+        run: cargo run --release -- -i latest.json -o latest.viz.json
       - uses: actions/upload-artifact@v3
         with:
           name: latest-result

--- a/.github/workflows/build-viz-state.yml
+++ b/.github/workflows/build-viz-state.yml
@@ -1,9 +1,14 @@
 on:
   workflow_call:
-
+    inputs:
+      filter:
+        type: string
+        default: "Unknown"
 jobs:
   viz-state:
     runs-on: ubuntu-latest
+    env:
+      FILTER: ${{ inputs.filter  }}
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -12,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: runziggurat/crunchy
-      - run: cargo run --release -- -i latest.json -o latest.viz.json
+      - run: cargo run --release -- -f $FILTER -i latest.json -o latest.viz.json
       - uses: actions/upload-artifact@v3
         with:
           name: latest-result


### PR DESCRIPTION
The caller needs to specify input `filter`, which will be either 'Zcash' or 'Ripple' depending on the crawler. The filter is directly passed to crunchy `-f` option.