### PR TITLE
`continue-on-error` for `build-viz-state`.

### DIFF
--- a/.github/workflows/build-viz-state.yml
+++ b/.github/workflows/build-viz-state.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   viz-state:
     runs-on: ubuntu-latest
+    continue-on-error: true
     env:
       FILTER: ${{ inputs.filter }}
     steps:


### PR DESCRIPTION
Not having a viz file, for example in the case of XRPL currently, will be handled in the GUI instead.  