### PR TITLE
ci: compile ziggurat with nightly rust

### DIFF
--- a/.github/workflows/build-ziggurat.yml
+++ b/.github/workflows/build-ziggurat.yml
@@ -12,7 +12,7 @@ jobs:
       EXTRA_ARGS: ${{ inputs.features }}
     steps:
       - uses: actions/checkout@v3
-      - run: rustup toolchain install stable --profile minimal
+      - run: rustup toolchain install nightly --profile minimal
       - name: Compile unit tests
         run: cargo test --all-targets --no-run $EXTRA_ARGS
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
`-Z` flag is now only usable with the nightly compiler which we use to output test results to `jsonl`.