### PR TITLE
ci: introduce the main test suite action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,43 @@
+name: 'Run Ziggurat test suite'
+
+inputs:
+  node-name:
+    type: string
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: ziggurat-config
+        path: ~/.ziggurat
+    - uses: actions/download-artifact@v3
+      with:
+        name: ziggurat-executable
+        path: ./ziggurat
+    - uses: actions/download-artifact@v3
+      with:
+        name: node-executable
+        path: ./
+    - name: Make node executable
+      shell: bash
+      env:
+        NODE_NAME: ${{ inputs.node-name }}
+      run: chmod +x ./"$NODE_NAME"
+    - name: Cleanup temp files and prepare test binary
+      shell: bash
+      run: |
+        rm ./ziggurat/*.d
+        mv ./ziggurat/ziggurat_* ziggurat_test
+        chmod +x ziggurat_test
+    - name: Run ziggurat suite
+      shell: bash
+      continue-on-error: true
+      run: ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json >> latest.jsonl
+    - run: cat latest.jsonl
+      shell: bash
+    - uses: actions/upload-artifact@v3
+      with:
+        name: latest-result
+        path: latest.jsonl

--- a/action.yml
+++ b/action.yml
@@ -15,15 +15,6 @@ runs:
       with:
         name: ziggurat-executable
         path: ./ziggurat
-    - uses: actions/download-artifact@v3
-      with:
-        name: node-executable
-        path: ./
-    - name: Make node executable
-      shell: bash
-      env:
-        NODE_NAME: ${{ inputs.node-name }}
-      run: chmod +x ./"$NODE_NAME"
     - name: Cleanup temp files and prepare test binary
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   node-name:
     type: string
     required: true
+  commit-hash:
+    type: string
+    required: true
 
 runs:
   using: "composite"
@@ -31,6 +34,14 @@ runs:
         rm ./ziggurat/*.d
         mv ./ziggurat/ziggurat_* ziggurat_test
         chmod +x ziggurat_test
+    - name: Procure metadata
+      shell: bash
+      env:
+        NODE_NAME: ${{ inputs.node-name }}
+        COMMIT_HASH: ${{ inputs.commit-hash }}
+      run: |
+        echo "{ \"type\": \"node\", \"name\": \""$NODE_NAME"\" }" > latest.jsonl
+        echo "{ \"type\": \"node\", \"commit\": \""$COMMIT_HASH"\" }" >> latest.jsonl
     - name: Run ziggurat suite
       shell: bash
       continue-on-error: true

--- a/action.yml
+++ b/action.yml
@@ -13,10 +13,6 @@ runs:
   steps:
     - uses: actions/download-artifact@v3
       with:
-        name: ziggurat-config
-        path: ~/.ziggurat
-    - uses: actions/download-artifact@v3
-      with:
         name: ziggurat-executable
         path: ./ziggurat
     - uses: actions/download-artifact@v3


### PR DESCRIPTION
- Introduces a new composite test suite action:
  - Handles the procuring of test results and node metadata (will be used in GUI).
  - The action expects that the user has done the following: 
    - Properly configured Ziggurat's `config.toml`-file.
    - Set up a working node before-hand.

With this action, a CI implementation only has to set up a given node, and then grab the wanted metadata. All metadata fields (currently only `node-name` and `commit-hash`) will default to an empty string (`""`) if not supplied. 