### PR TITLE
ci: always use nightly rust when compiling Ziggurat tests

### DIFF
--- a/.github/workflows/build-ziggurat.yml
+++ b/.github/workflows/build-ziggurat.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup toolchain install nightly --profile minimal
       - name: Compile unit tests
-        run: cargo test --all-targets --no-run $EXTRA_ARGS
+        run: cargo +nightly test --all-targets --no-run $EXTRA_ARGS
       - uses: actions/upload-artifact@v3
         with:
           name: ziggurat-executable

--- a/.github/workflows/build-ziggurat.yml
+++ b/.github/workflows/build-ziggurat.yml
@@ -9,7 +9,7 @@ jobs:
   build-ziggurat:
     runs-on: ubuntu-latest
     env:
-      EXTRA_ARGS: ${{ inputs.features }}
+      EXTRA_ARGS: ${{ inputs.extra-args }}
     steps:
       - uses: actions/checkout@v3
       - run: rustup toolchain install nightly --profile minimal


### PR DESCRIPTION
- Fixes an issue where `cargo` would disallow the test suite to run.
- Additionally, fixes a misspelling that made it impossible to extend the base command.

*Details: a `cargo` update once again broke the test suite action. This PR forces the test suite to always compile using nightly rust, solving the issue for now. Next step is to pin the rust version with the help of Nix, just like we've done in `check-and-lint`.*